### PR TITLE
feat(authorization): refactoring authorization system by tdd

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -31,3 +31,6 @@ security:
         - { path: ^/users, roles: ROLE_ADMIN }
         - { path: ^/tasks, roles: ROLE_USER }
         - { path: ^/, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+
+    role_hierarchy:
+        ROLE_ADMIN: ROLE_USER

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,10 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>
+            <exclude>
+                <file>src/Kernel.php</file>
+                <directory suffix=".php">src/DataFixtures</directory>
+            </exclude>
         </whitelist>
     </filter>
 

--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 
 /**
  * Class TaskController.
@@ -188,6 +187,12 @@ class TaskController extends AbstractController
      */
     public function deleteTask(Task $task, TaskManager $taskManager): Response
     {
+        if (($task->getAuthor() !== null && $task->getAuthor() !== $this->getUser())
+            || ($task->getAuthor() === null && !$this->isGranted('ROLE_ADMIN'))
+        ) {
+            throw $this->createAccessDeniedException();
+        }
+
         $taskManager->deleteTask($task);
 
         $this->addFlash(

--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -9,6 +9,7 @@ namespace App\Controller;
 use App\Entity\Task;
 use App\Form\TaskType;
 use App\Manager\TaskManager;
+use App\Security\TaskVoter;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -187,11 +188,7 @@ class TaskController extends AbstractController
      */
     public function deleteTask(Task $task, TaskManager $taskManager): Response
     {
-        if (($task->getAuthor() !== null && $task->getAuthor() !== $this->getUser())
-            || ($task->getAuthor() === null && !$this->isGranted('ROLE_ADMIN'))
-        ) {
-            throw $this->createAccessDeniedException();
-        }
+        $this->denyAccessUnlessGranted(TaskVoter::DELETE, $task);
 
         $taskManager->deleteTask($task);
 

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  *
  * @ORM\Entity
  * @ORM\Table
- * @UniqueEntity(fields={"title"}, message="This task already exists")
+ * @UniqueEntity(fields={"title"}, message="This task already exists.")
  */
 class Task
 {
@@ -48,7 +48,15 @@ class Task
      * @var string
      *
      * @ORM\Column(type="string", unique=true)
-     * @Assert\NotBlank(message="Vous devez saisir un titre.")
+     *
+     * @Assert\NotBlank(message="You must choose a title.")
+     * @Assert\Length(
+     *     min=3,
+     *     max=30,
+     *     minMessage="The title should contain at least {{ limit }} characters.",
+     *     maxMessage="The title should not contain more than {{ limit }} characters.",
+     *     allowEmptyString=false
+     * )
      */
     private $title;
 
@@ -56,7 +64,12 @@ class Task
      * @var string
      *
      * @ORM\Column(type="text")
-     * @Assert\NotBlank(message="Vous devez saisir du contenu.")
+     * @Assert\NotBlank(message="You must add a content.")
+     * @Assert\Length(
+     *     min=10,
+     *     minMessage="The content should contain at least {{ limit }} characters.",
+     *     allowEmptyString=false
+     * )
      */
     private $content;
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -211,13 +211,7 @@ class User implements UserInterface
      */
     public function getRoles(): array
     {
-        $roles = $this->roles;
-        // guarantee every user at least has ROLE_USER
-        if (!$roles) {
-            $roles[] = 'ROLE_USER';
-        }
-
-        return array_unique($roles);
+        return $this->roles;
     }
 
     /**
@@ -227,7 +221,7 @@ class User implements UserInterface
      */
     public function setRoles(array $roles): self
     {
-        $this->roles = $roles;
+        $this->roles = array_unique($roles);
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -18,7 +18,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  *
  * @ORM\Table("user")
  * @ORM\Entity
- * @UniqueEntity(fields={"email"}, message="This email already exists")
+ * @UniqueEntity(fields={"email"}, message="This email already exists.")
  */
 class User implements UserInterface
 {
@@ -36,7 +36,14 @@ class User implements UserInterface
      *
      * @ORM\Column(type="string", length=25, unique=true)
      *
-     * @Assert\NotBlank(message="Vous devez saisir un nom d'utilisateur.")
+     * @Assert\NotBlank(message="You must choose a username.")
+     * @Assert\Length(
+     *     min=3,
+     *     max=25,
+     *     minMessage="The username should contain at least {{ limit }} characters.",
+     *     maxMessage="The username should not contain more than {{ limit }} characters.",
+     *     allowEmptyString=false
+     * )
      */
     private $username;
 
@@ -44,6 +51,13 @@ class User implements UserInterface
      * @var string The hashed password
      *
      * @ORM\Column(type="string", length=64)
+     *
+     * @Assert\NotBlank(message="You must choose a password.")
+     * @Assert\Length(
+     *     min=5,
+     *     minMessage="Your password should contain at least {{ limit }} characters.",
+     *     allowEmptyString=false
+     * )
      */
     private $password;
 
@@ -52,9 +66,9 @@ class User implements UserInterface
      *
      * @ORM\Column(type="string", length=60, unique=true)
      *
-     * @Assert\NotBlank(message="Vous devez saisir une adresse email.")
+     * @Assert\NotBlank(message="You must enter an email.")
      * @Assert\Email(
-     *     message="Le format de l'adresse n'est pas correcte."
+     *     message="The Email '{{ value }}' is not a valid email."
      * )
      */
     private $email;
@@ -199,7 +213,9 @@ class User implements UserInterface
     {
         $roles = $this->roles;
         // guarantee every user at least has ROLE_USER
-        $roles[] = 'ROLE_USER';
+        if (!$roles) {
+            $roles[] = 'ROLE_USER';
+        }
 
         return array_unique($roles);
     }

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -7,6 +7,8 @@
 namespace App\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -48,6 +50,24 @@ class UserType extends AbstractType
                 'email',
                 EmailType::class,
                 ['label' => 'Adresse email']
+            )
+            ->add(
+                'roles',
+                CollectionType::class,
+                [
+                    'entry_type' => ChoiceType::class,
+                    'entry_options' =>
+                    [
+                        'label' => false,
+                        'choices' =>
+                            [
+                                'Administrateur' => 'ROLE_ADMIN',
+                                'Utilisateur' => 'ROLE_USER',
+                            ],
+                        'multiple'        => false,
+                        'expanded'        => true,
+                    ],
+                ]
             )
         ;
     }

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -7,8 +7,8 @@
 namespace App\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -53,22 +53,29 @@ class UserType extends AbstractType
             )
             ->add(
                 'roles',
-                CollectionType::class,
+                ChoiceType::class,
                 [
-                    'entry_type' => ChoiceType::class,
-                    'entry_options' =>
-                    [
-                        'label' => false,
-                        'choices' =>
-                            [
-                                'Administrateur' => 'ROLE_ADMIN',
-                                'Utilisateur' => 'ROLE_USER',
-                            ],
-                        'multiple'        => false,
-                        'expanded'        => true,
-                    ],
+                    'choices' =>
+                        [
+                            'Utilisateur' => 'ROLE_USER',
+                            'Administrateur' => 'ROLE_ADMIN',
+                        ],
+                    'required' => true,
+                    'multiple' => false,
+                    'expanded' => true,
                 ]
             )
+        ;
+
+        $builder->get('roles')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($rolesArray) {
+                    return count($rolesArray) ? $rolesArray[0]: null;
+                },
+                function ($rolesString) {
+                    return [$rolesString];
+                }
+            ))
         ;
     }
 }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -11,9 +11,6 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ManagerRegistry;
-use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
-use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Class UserRepository.
@@ -23,7 +20,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @method User[]    findAll()
  * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
+class UserRepository extends ServiceEntityRepository
 {
     /**
      * UserRepository constructor.
@@ -80,33 +77,6 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     public function delete(User $user): void
     {
         $this->_em->remove($user);
-        $this->_em->flush();
-    }
-
-    /**
-     * Used to upgrade (rehash) user's password automatically over time.
-     *
-     * @param UserInterface $user
-     * @param string        $newEncodedPassword
-     *
-     * @return void
-     *
-     * @throws ORMException
-     * @throws OptimisticLockException
-     */
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
-    {
-        if (!$user instanceof User) {
-            throw new UnsupportedUserException(
-                sprintf(
-                    'Instances of "%s" are not supported.',
-                    \get_class($user)
-                )
-            );
-        }
-
-        $user->setPassword($newEncodedPassword);
-        $this->_em->persist($user);
         $this->_em->flush();
     }
 }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -110,4 +110,3 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $this->_em->flush();
     }
 }
-

--- a/src/Security/TaskVoter.php
+++ b/src/Security/TaskVoter.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * (c) Adrien PIERRARD
+ */
+
+namespace App\Security;
+
+use App\Entity\Task;
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Class TaskVoter.
+ */
+class TaskVoter extends Voter
+{
+    /**
+     * A constant that represent an action.
+     *
+     * @var string
+     */
+    const DELETE = 'delete';
+
+    /**
+     * An AuthorizationCheckerInterface Injection.
+     *
+     * @var AuthorizationCheckerInterface
+     */
+    private $authorizationChecker;
+
+    /**
+     * TaskVoter constructor.
+     *
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     */
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker)
+    {
+        $this->authorizationChecker = $authorizationChecker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function supports($attribute, $subject)
+    {
+        if (!in_array($attribute, [self::DELETE])) {
+            return false;
+        }
+
+        if (!$subject instanceof Task) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        /** @var Task $task */
+        $task = $subject;
+
+        if (null !== $task->getAuthor()) {
+            return $user === $task->getAuthor();
+        }
+
+        return $this->authorizationChecker->isGranted('ROLE_ADMIN');
+    }
+}

--- a/templates/user/edit.html.twig
+++ b/templates/user/edit.html.twig
@@ -6,9 +6,9 @@
 {% block body %}
     <div class="row">
         {{ form_start(form, {'action' : path('user_edit', {'id' : user.id})}) }}
-        {{ form_widget(form) }}
+            {{ form_widget(form) }}
 
-        <button type="submit" class="btn btn-success pull-right">Modifier</button>
+            <button type="submit" class="btn btn-success pull-right">Modifier</button>
         {{ form_end(form) }}
     </div>
 {% endblock %}

--- a/templates/user/list.html.twig
+++ b/templates/user/list.html.twig
@@ -28,6 +28,13 @@
                         <td>{{ user.username }}</td>
                         <td>{{ user.email }}</td>
                         <td>
+                            {% if 'ROLE_ADMIN' in user.roles %}
+                                Administrateur
+                            {% else %}
+                                Utilisateur
+                            {% endif %}
+                        </td>
+                        <td>
                             <a href="{{ path('user_edit', {'id' : user.id}) }}" class="btn btn-success btn-sm">Edit</a>
                             <form method="POST"
                                   class="delete-form"

--- a/tests/Functional/Controller/HomeControllerTest.php
+++ b/tests/Functional/Controller/HomeControllerTest.php
@@ -22,7 +22,7 @@ class HomeControllerTest extends WebTestCase
     private $client;
 
     /**
-     * Set up the EntityManager.
+     * Set up the client.
      *
      * @return void
      */
@@ -40,7 +40,7 @@ class HomeControllerTest extends WebTestCase
      */
     public function testIndex(): void
     {
-        $crawler = $this->client->request(
+        $this->client->request(
             'GET',
             '/'
         );

--- a/tests/Functional/Controller/SecurityControllerTest.php
+++ b/tests/Functional/Controller/SecurityControllerTest.php
@@ -22,7 +22,7 @@ class SecurityControllerTest extends WebTestCase
     private $client;
 
     /**
-     * Set up the EntityManager.
+     * Set up the client.
      *
      * @return void
      */
@@ -53,6 +53,102 @@ class SecurityControllerTest extends WebTestCase
         $this->assertResponseRedirects('/');
         $crawler = $this->client->followRedirect();
         $this->assertSame(0, $crawler->filter('div.alert.alert-danger')->count());
+    }
+
+    /**
+     * Test to access protected URI with login.
+     *
+     * @return void
+     */
+    public function testLoginProtectedUri(): void
+    {
+        $this->client->request(
+            'GET',
+            '/tasks/todo'
+        );
+
+        $crawler = $this->client->followRedirect();
+        $this->assertResponseStatusCodeSame(200);
+
+        $form = $crawler->selectButton('Se connecter')->form();
+        $form['username'] = 'user2';
+        $form['password'] = 'demo2';
+        $this->client->submit($form);
+
+        $this->assertTrue($this->client->getResponse()->isRedirection());
+        $crawler = $this->client->followRedirect();
+        $this->assertSame(0, $crawler->filter('div.alert.alert-danger')->count());
+    }
+
+    /**
+     * Test to access User Admin by User without ROLE_ADMIN.
+     *
+     * @return void
+     */
+    public function testLoginUserAdmin(): void
+    {
+        $this->client->request(
+            'GET',
+            '/users'
+        );
+
+        $crawler = $this->client->followRedirect();
+        $this->assertResponseStatusCodeSame(200);
+
+        $form = $crawler->selectButton('Se connecter')->form();
+        $form['username'] = 'user1';
+        $form['password'] = 'demo1';
+        $this->client->submit($form);
+
+        $this->assertTrue($this->client->getResponse()->isRedirection());
+        $this->client->followRedirect();
+        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * Login test with bad user.
+     *
+     * @return void
+     */
+    public function testLoginBadUser(): void
+    {
+        $crawler = $this->client->request(
+            'GET',
+            '/login'
+        );
+
+        $form = $crawler->selectButton('Se connecter')->form();
+        $form['username'] = 'baduser1';
+        $form['password'] = 'wrongpass1';
+        $this->client->submit($form);
+
+        $this->assertResponseRedirects('/login');
+        $crawler = $this->client->followRedirect();
+        $this->assertSame(1, $crawler->filter('div.alert.alert-danger')->count());
+    }
+
+    /**
+     * Login test with bad csrf token.
+     *
+     * @return void
+     */
+    public function testLoginBadToken(): void
+    {
+        $csrfToken = $this->client->getContainer()->get('security.csrf.token_manager')->getToken('authenticate');
+
+        $this->client->request(
+            'POST',
+            '/login',
+            [
+                'username' => 'user1',
+                'password' => 'demo1',
+                '_token' => $csrfToken,
+            ]
+        );
+
+        $this->assertResponseRedirects('/login');
+        $crawler = $this->client->followRedirect();
+        $this->assertSame(1, $crawler->filter('div.alert.alert-danger')->count());
     }
 
     /**

--- a/tests/Functional/Controller/UserControllerTest.php
+++ b/tests/Functional/Controller/UserControllerTest.php
@@ -31,7 +31,7 @@ class UserControllerTest extends WebTestCase
     private $entityManager;
 
     /**
-     * Set up the EntityManager.
+     * Set up the client and the EntityManager.
      *
      * @return void
      */

--- a/tests/Unit/Entity/TaskTest.php
+++ b/tests/Unit/Entity/TaskTest.php
@@ -9,7 +9,6 @@ namespace App\Tests\Unit\Entity;
 use App\Entity\Task;
 use App\Entity\User;
 use DateTime;
-use Doctrine\Common\Collections\Collection;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -59,7 +59,7 @@ class UserTest extends TestCase
         $this->assertEquals(null, $user->getEmail());
         $this->assertEquals(null, $user->getPassword());
         $this->assertInstanceOf(Collection::class, $user->getTasks());
-        $this->assertEquals(['ROLE_USER'], $user->getRoles());
+        $this->assertEquals([], $user->getRoles());
 
         $user->setUsername(self::USER_USERNAME);
         $this->assertEquals(self::USER_USERNAME, $user->getUsername());


### PR DESCRIPTION
Hello Rui,
Could you please review this feature ? Thanks in advance.

Purpose :
I made some tests linked to expectations regarding authorization and roles.
Then i refactored the code to pass tests.
Now, when you create a User, it is possible to choose a role for him (ROLE_USER or ROLE_ADMIN)
You can edit User's role after creation too.
Only Admin Users can access to the User CRUD system.
An Admin User can delete his own Task or Task created as anonymous author.
A simple User can't access to User Admin and can't delete Task created by an anonymous author.
Whatever the User, he can only delete Tasks created by himself.
We consider that a Task created by an Anonymous author is a Task already created in the App before the user authentication system implementation.
Now when you create a Task, the current logged in User is assigned as Author.
It's not possible to change the Author when you edit a Task as expected.

Automated tests in place cover all expected functionality and more.

At this step, all ToDo & Co expectation are implemented for this project.
Improvement can be made but will take part of the improvement plan that will be define thanks to Quality & Performance Audit in the next step.

Link to my project issue : #7 / #11 